### PR TITLE
Update readme to include server time accuracy statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,7 @@ $ crontab -e
 ## Notes
 slackcamp needs to be able to write to a file named `last_run_date.txt` within it's directory. This is so that when we don't get duplicate events from Basecamp.
 
+slackcamp also relies on the accuracy of PHP's `date()` function. If the server time is inaccurate, you may receive duplicate (or missing) messages.
+
 ## Thanks
 [netvlies / basecamp-php](https://github.com/netvlies/basecamp-php) - PHP Implementation of the all new Basecamp API


### PR DESCRIPTION
I ran into another issue today where slackcamp would post duplicate messages on each run. I tracked it down to the server clock being slow by about 30 seconds. It was fixed as soon as I installed NTP.

I updated the README to include that information.
