### PR TITLE
Fixes #7, now uses the new Slack Webhook URLs

### DIFF
--- a/config.default.php
+++ b/config.default.php
@@ -4,7 +4,7 @@ define('BASECAMP_USERNAME', 'basecamp_username');
 define('BASECAMP_PASSWORD', 'basecamp_password');
 define('BASECAMP_ID', '999999'); // http://basecamp.com/<BASECAMP_ID>
 define('SLACK_INSTANCE', 'slack_instance_name'); // http://<SLACK_INSTANCE>.slack.com
-define('SLACK_API_TOKEN', 'slack_api_token');
+define('SLACK_WEBHOOK_URL', 'slack_webhook_url'); // https://hooks.slack.com/services/<webhook_url>
 define('SLACK_BOT_NAME', 'basecamp');
 define('SLACK_BOT_ICON', ''); // full URL to bot icon
 define('SLACK_DEFAULT_CHANNEL', '#basecamp'); // the default channel that messages will be posted to

--- a/slackcamp.php
+++ b/slackcamp.php
@@ -6,11 +6,7 @@ require __DIR__ . '/config.php';
 function slack_notify($msg, $channel, $attachment)
 {
     $curl = curl_init();
-    $url = sprintf(
-        'https://%s.slack.com/services/hooks/incoming-webhook?token=%s',
-        SLACK_INSTANCE,
-        SLACK_API_TOKEN
-    );
+    $url = SLACK_WEBHOOK_URL;
     curl_setopt($curl, CURLOPT_URL, $url);
     curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'POST');
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Slack updated their URL structure for webhooks, no longer requiring an
API key. This commit changes slackcamp to use this new structure.
