### PR TITLE
Add rudimentary OAuth; Tidy-up; Add option of function to map projects to channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 config.php
 last_run_date.txt
 vendor
+var
+custom.php
+

--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ $ crontab -e
 */1 * * * * php /slackcamp/slackcamp.php
 ```
 
+### Using OAuth
+
+If OAuth is required rather than normal username/password, a Basecamp integration must be set up on [Basecamp's Developers page](http://integrate.37signals.com), and the appropriate values entered into the slackcamp configuration.  Additionally, `oauth.php` must be accessible from the configured `Redirect URI` and able to write to the location determined by `BASECAMP_OAUTH2_TOKEN_FILE`.  This file should then be secured against reading by the webserver.
+
+Unfortunately, OAuth doesn't add much in the way of security to the script, as an OAuth token issued by Basecamp has most of the same capabilities via the API as a Username/Password combination, rather than the ability to set a limited capability token (eg. read only) as you might expect.  Still, it prevents the account itself being stolen.
+
 ## Notes
-slackcamp needs to be able to write to a file named `last_run_date.txt` within it's directory. This is so that when we don't get duplicate events from Basecamp.
+slackcamp needs to be able to write to a file named `last_run_date.txt` within its directory, or another directory if configured that way. This is so that when we don't get duplicate events from Basecamp.
 
 slackcamp also relies on the accuracy of PHP's `date()` function. If the server time is inaccurate, you may receive duplicate (or missing) messages.
 

--- a/config.default.php
+++ b/config.default.php
@@ -33,17 +33,36 @@ define('LAST_RUN_FILENAME', __DIR__.'/last_run_date.txt');
 
 if( ! @include_once(__DIR__.'/custom.php')) {
 
-    $slack_channels = function ($basecamp_project_name, $event) {
+    $slack_channels = function ($basecamp_project_name, $event, $service) {
         // Given an input Basecamp project name, this function should
         // return a Slack channel name to post to, or an empty string
         // if the event is to be ignored.
+        //
+        // The raw $event object is passed; you can use this to filter out
+        // messages, eg. by checking $event['action'] and returning ''
+        // unless the action starts with "commented on", "added",
+        // "posted", "created", etc.
+        //
+        // Also, $service -- a handle to the BasecampClient in use -- is
+        // passed to allow this function to do more investigation.  A good
+        // use of this would be to include the Slack channel hashtag in
+        // the Basecamp project's `description` field... remember to cache
+        // the API queries though!
+
+        // If the Basecamp project name itself contains a hashtag, then
+        // assume it's the Slack channel
+        if (preg_match('/(#\w+)/', $basecamp_project_name, $parts))
+            return $parts[1];
+
+        // Otherwise, use some other code to determine the Slack channel,
+        // if any.
 
         switch ($basecamp_project_name) {
         case 'Basecamp Project Name':
             return '#slack_channel_name';
 
         case 'Basecamp Project I Do Not Care About':
-            return '';
+            return ''; // An empty string means "discard the event"
 
         default:
             // If not previously matched, then default.  Alternatively, change

--- a/config.default.php
+++ b/config.default.php
@@ -2,39 +2,63 @@
 
 define('BASECAMP_USERNAME', 'basecamp_username');
 define('BASECAMP_PASSWORD', 'basecamp_password');
+
+/*
+//// or alternatively:
+define('BASECAMP_OAUTH2_CLIENT_ID', ''); // Fill this in with values from integrate.37signals.com
+define('BASECAMP_OAUTH2_CLIENT_SECRET', '');
+define('BASECAMP_OAUTH2_REDIRECT_URI', '');
+
+define('BASECAMP_OAUTH2_TOKEN_FILE', __DIR__.'/basecamp_auth.json'); // Note, this needs to be writeable by the script running BASECAMP_OAUTH2_REDIRECT_URI, ie. the webserver
+*/
+
+
 define('BASECAMP_ID', '999999'); // http://basecamp.com/<BASECAMP_ID>
 define('SLACK_INSTANCE', 'slack_instance_name'); // http://<SLACK_INSTANCE>.slack.com
 define('SLACK_WEBHOOK_URL', 'slack_webhook_url'); // https://hooks.slack.com/services/<webhook_url>
 define('SLACK_BOT_NAME', 'basecamp');
 define('SLACK_BOT_ICON', ''); // full URL to bot icon
 define('SLACK_DEFAULT_CHANNEL', '#basecamp'); // the default channel that messages will be posted to
+define('SLACK_INCLUDE_ATTACHMENT', false); // Do we want a full attachment formatted Slack message?
+
 define('LAST_RUN_FILENAME', __DIR__.'/last_run_date.txt');
 
-$slack_channels = function ($basecamp_project_name, $event) {
-    // Given an input Basecamp project name, this function should
-    // return a Slack channel name to post to, or an empty string
-    // if the event is to be ignored.
 
-    switch ($basecamp_project_name) {
-    case 'Basecamp Project Name':
-        return '#slack_channel_name';
+// Mapping Basecamp Projects to Slack Channels:
+//
+// Define $slack_channels as a function/callable, or as an array.
 
-    case 'Basecamp Project I Do Not Care About':
-        return '';
+// Or, if `custom.php` exists, use that instead.  This allows for complex
+// custom mappings.
 
-    default:
-        // If not previously matched, then default.  Alternatively, change
-        // this to return an empty string to ignore the event.
-        return SLACK_DEFAULT_CHANNEL;
-    }
-};
+if( ! @include_once(__DIR__.'/custom.php')) {
 
-if (false) {
+    $slack_channels = function ($basecamp_project_name, $event) {
+        // Given an input Basecamp project name, this function should
+        // return a Slack channel name to post to, or an empty string
+        // if the event is to be ignored.
+
+        switch ($basecamp_project_name) {
+        case 'Basecamp Project Name':
+            return '#slack_channel_name';
+
+        case 'Basecamp Project I Do Not Care About':
+            return '';
+
+        default:
+            // If not previously matched, then default.  Alternatively, change
+            // this to return an empty string to ignore the event.
+            return SLACK_DEFAULT_CHANNEL;
+        }
+    };
+
+    /*
     // Alternative approach: just hardcode the project names in an
     // associative array.  If the array does not contain the key for a
     // project, it'll default to SLACK_DEFAULT_CHANNEL.  If the array does
     // contain a key but the value is empty, it'll ignore the event.
     $slack_channels = array(
-        'Basecamp Project Name' => '#slack_channel_name'
+      'Basecamp Project Name' => '#slack_channel_name'
     );
+    */
 }

--- a/config.default.php
+++ b/config.default.php
@@ -10,6 +10,31 @@ define('SLACK_BOT_ICON', ''); // full URL to bot icon
 define('SLACK_DEFAULT_CHANNEL', '#basecamp'); // the default channel that messages will be posted to
 define('LAST_RUN_FILENAME', __DIR__.'/last_run_date.txt');
 
-$slack_channels = array(
-    'Basecamp Project Name' => '#slack_channel_name'
-);
+$slack_channels = function ($basecamp_project_name, $event) {
+    // Given an input Basecamp project name, this function should
+    // return a Slack channel name to post to, or an empty string
+    // if the event is to be ignored.
+
+    switch ($basecamp_project_name) {
+    case 'Basecamp Project Name':
+        return '#slack_channel_name';
+
+    case 'Basecamp Project I Do Not Care About':
+        return '';
+
+    default:
+        // If not previously matched, then default.  Alternatively, change
+        // this to return an empty string to ignore the event.
+        return SLACK_DEFAULT_CHANNEL;
+    }
+};
+
+if (false) {
+    // Alternative approach: just hardcode the project names in an
+    // associative array.  If the array does not contain the key for a
+    // project, it'll default to SLACK_DEFAULT_CHANNEL.  If the array does
+    // contain a key but the value is empty, it'll ignore the event.
+    $slack_channels = array(
+        'Basecamp Project Name' => '#slack_channel_name'
+    );
+}

--- a/config.default.php
+++ b/config.default.php
@@ -8,6 +8,7 @@ define('SLACK_WEBHOOK_URL', 'slack_webhook_url'); // https://hooks.slack.com/ser
 define('SLACK_BOT_NAME', 'basecamp');
 define('SLACK_BOT_ICON', ''); // full URL to bot icon
 define('SLACK_DEFAULT_CHANNEL', '#basecamp'); // the default channel that messages will be posted to
+define('LAST_RUN_FILENAME', __DIR__.'/last_run_date.txt');
 
 $slack_channels = array(
     'Basecamp Project Name' => '#slack_channel_name'

--- a/oauth.php
+++ b/oauth.php
@@ -1,0 +1,94 @@
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/config.php';
+
+
+try {
+
+    if(file_exists(BASECAMP_OAUTH2_TOKEN_FILE)) {
+        $auth_json = file_get_contents(BASECAMP_OAUTH2_TOKEN_FILE);
+        $auth = json_decode($auth_json);
+
+        if(3600 > $auth->expires_at - time()) {
+            $params = array(
+                'type' => 'refresh',
+                'client_id' => BASECAMP_OAUTH2_CLIENT_ID,
+                'redirect_uri' => BASECAMP_OAUTH2_REDIRECT_URI,
+                'client_secret' => BASECAMP_OAUTH2_CLIENT_SECRET,
+                'refresh_token' => $auth->refresh_token
+            );
+
+            $ch = curl_init(BASECAMP_OAUTH2_ACCESS_URI);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+            curl_setopt($ch, CURLOPT_HEADER, false);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, rawurldecode(http_build_query($params)));
+            $response = curl_exec( $ch );
+            curl_close($ch);
+
+            if (0 !== strpos($response, '{"'))
+                throw new Exception($response);
+
+            print_r($response);
+            exit;
+        }
+    }
+
+    if(isset($_GET['code']) and !empty($_GET['code'])) {
+
+        $params = array(
+            'type' => 'web_server',
+            'client_id' => BASECAMP_OAUTH2_CLIENT_ID,
+            'redirect_uri' => BASECAMP_OAUTH2_REDIRECT_URI,
+            'client_secret' => BASECAMP_OAUTH2_CLIENT_SECRET,
+            'code' => $_GET['code']
+        );
+
+        $ch = curl_init(BASECAMP_OAUTH2_ACCESS_URI);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+        curl_setopt($ch, CURLOPT_HEADER, false);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, rawurldecode(http_build_query($params)));
+
+        $response = curl_exec( $ch );
+        curl_close($ch);
+
+        if (0 !== strpos($response, '{"'))
+            throw new Exception('Bad response: '.$response);
+
+        $res = json_decode($response, true);
+
+        if(!isset($res['refresh_token']))
+            throw new Exception($response);
+
+        $res['expires_at'] = time() + $res['expires_in'];
+
+        $auth = json_encode($res);
+
+        if(!file_put_contents(BASECAMP_OAUTH2_TOKEN_FILE, $auth))
+            throw new Exception("Could not write file ".BASECAMP_OAUTH2_TOKEN_FILE.": $auth");
+
+        echo 'Done.';
+    }
+
+    else {
+        $params = array(
+            'type' => 'web_server',
+            'client_id' => BASECAMP_OAUTH2_CLIENT_ID,
+            'redirect_uri' => BASECAMP_OAUTH2_REDIRECT_URI
+        );
+
+        $url = BASECAMP_OAUTH2_REQUEST_URI.'?'.http_build_query($params);
+
+        Header("Location: $url");
+        print '<a href="'.$url.'>'.$url.'</a>';
+    }
+}
+catch (Exception $e) {
+    echo "<h1>Error</h1>";
+    echo "<pre>";
+    echo htmlentities($e->getMessage());
+}

--- a/slackcamp.php
+++ b/slackcamp.php
@@ -3,33 +3,6 @@
 require __DIR__ . '/vendor/autoload.php';
 require __DIR__ . '/config.php';
 
-function slack_notify($msg, $channel, $attachment)
-{
-    $curl = curl_init();
-    $url = SLACK_WEBHOOK_URL;
-    curl_setopt($curl, CURLOPT_URL, $url);
-    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'POST');
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-    $payload = array(
-        'channel' => $channel,
-        'username' => SLACK_BOT_NAME,
-        'text' => $msg
-    );
-    $bot_icon = SLACK_BOT_ICON;
-    if (preg_match('/^:[a-z0-9_\-]+:$/i', $bot_icon)) {
-        $payload['icon_emoji'] = $bot_icon;
-    } elseif ($bot_icon) {
-        $payload['icon_url'] = $bot_icon;
-    }
-    if ($attachment) {
-        $payload['attachments'] = array($attachment);
-    }
-    $data = 'payload=' . json_encode($payload);
-    curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
-    curl_exec($curl);
-    curl_close($curl);
-    echo "\n" . 'message sent to ' . $channel;
-}
 
 try {
     // last run file name
@@ -118,3 +91,40 @@ try {
     echo "\n" . $except->getMessage();
 }
 echo "\n" . 'DONE!' . "\n";
+
+exit;
+
+
+function slack_notify($msg, $channel, $attachment)
+    // Send a message to Slack
+{
+    $curl = curl_init();
+    $url = SLACK_WEBHOOK_URL;
+    curl_setopt($curl, CURLOPT_URL, $url);
+    curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
+    curl_setopt($curl, CURLOPT_HEADER, false);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+    $payload = array(
+        'channel' => $channel,
+        'username' => SLACK_BOT_NAME,
+        'text' => $msg
+    );
+    $bot_icon = SLACK_BOT_ICON;
+    if (preg_match('/^:[a-z0-9_\-]+:$/i', $bot_icon)) {
+        $payload['icon_emoji'] = $bot_icon;
+    } elseif ($bot_icon) {
+        $payload['icon_url'] = $bot_icon;
+    }
+    if ($attachment) {
+        $payload['attachments'] = array($attachment);
+    }
+    //    $data = 'payload=' . json_encode($payload);
+    $data = json_encode($payload);
+    print_r($data);
+    curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+    $ret = curl_exec($curl);
+    curl_close($curl);
+
+    return $ret;
+}

--- a/slackcamp.php
+++ b/slackcamp.php
@@ -84,7 +84,16 @@ try {
 
         // see if a specific slack channel is set for notifications
         $channel = SLACK_DEFAULT_CHANNEL;
-        if (isset($slack_channels[$event['bucket']['name']])) {
+
+        // If $slack_channels is a callable, eg. a function, then call it
+        // to deduce the channel name.
+        if (is_callable($slack_channels)) {
+            $channel = call_user_func($slack_channels, $event['bucket']['name'], $event);
+        }
+
+        // Or, if it's an associative array containing an entry for the
+        // Basecamp project name, use it.
+        else if (is_array($slack_channels) and isset($slack_channels[$event['bucket']['name']])) {
             $channel = $slack_channels[$event['bucket']['name']];
         }
 

--- a/slackcamp.php
+++ b/slackcamp.php
@@ -33,12 +33,11 @@ function slack_notify($msg, $channel, $attachment)
 
 try {
     // last run file name
-    $last_run_filename = dirname(__FILE__) . '/last_run_date.txt';
     $save_last_run_date = false;
 
     // set the default last run date
-    if (file_exists($last_run_filename)) {
-        $last_run_date = file_get_contents($last_run_filename);
+    if (file_exists(LAST_RUN_FILENAME)) {
+        $last_run_date = file_get_contents(LAST_RUN_FILENAME);
     } else {
         $last_run_date = date('c');
         $save_last_run_date = true;
@@ -101,7 +100,7 @@ try {
 
     // persist the last run date
     if ($save_last_run_date) {
-        $last_run_fp = fopen($last_run_filename, 'w');
+        $last_run_fp = fopen(LAST_RUN_FILENAME, 'w');
         fwrite($last_run_fp, $last_run_date);
         fclose($last_run_fp);
         echo "\n" . 'setting last run date to ' . $last_run_date;


### PR DESCRIPTION
This PR contains some reorganisation and two new features we needed in-house:
- **OAuth 2.0 flow**: unfortunately, as noted in the README the security gained by using OAuth isn't actually as significant as I'd like.  It's rudimentary, but implemented without any extra dependencies.
- **Basecamp to Slack mapping as a function**:  Rather than the static array to map Basecamp project names to Slack channels (which is still supported) you can specify a callable/function to determine the Slack channel algorithmically (eg. based on Basecamp project description), and to filter messages (eg. discard "completed to-do", "moved" events; by returning an empty channel from the function)

There are some other small changes included too.  I realise it's a reasonably substantial PR, so feel free to cherry-pick, or reject entirely!
